### PR TITLE
Convertignore patch

### DIFF
--- a/src/@UNIF_base/.convertignore
+++ b/src/@UNIF_base/.convertignore
@@ -4,6 +4,7 @@ key.json
 *.bisign
 *.wss
 *.sqf
+*.paa
 *.ogg
 texHeaders.bin
 mod.cpp

--- a/src/@UNIF_bwmod/.convertignore
+++ b/src/@UNIF_bwmod/.convertignore
@@ -5,6 +5,7 @@ key.json
 *.wss
 *.sqf
 *.ogg
+*.paa
 texHeaders.bin
 mod.cpp
 meta.cpp


### PR DESCRIPTION
Needed if we want to keep .paa files as well as regular image files.
While i would suggest keeping only regular image files, until the main people know how to use [the packing tool](https://github.com/estchd/arma_mod_packing), it's probably gonna be better.