### PR TITLE
Prevent FWA MGs belt unwrapping

### DIFF
--- a/src/@UNIF BASE/addons/UNIF_Belt_Fix/Config.cpp
+++ b/src/@UNIF BASE/addons/UNIF_Belt_Fix/Config.cpp
@@ -1,0 +1,46 @@
+class CfgPatches
+{
+	class UNIF_Belt_Fix
+	{
+		requiredaddons[]=
+		{
+			"sp_fwa_machinegun_core"
+		};
+		requiredversion=0.1;
+		units[]={};
+		weapons[]={};
+		magazines[]={};
+	};
+};
+class CfgFunctions
+{
+	class GRCB
+	{
+		class Misc
+		{
+			class machinegunrested
+			{
+				tag="GRCB";
+				description="switches hand animation when weapon is rested";
+				file="UNIF_Belt_Fix\fncs\fnc_gpmgweaponrested.sqf";
+			};
+		};
+	};
+};
+class RscInGameUI
+{
+	class RscWeaponZeroing;
+	class GRCB_machinegun_animation: RscWeaponZeroing
+	{
+		onLoad="_this call GRCB_fnc_machinegunrested;";
+	};
+};
+class CfgWeapons
+{
+	class sp_fwa_rifle_762_base;
+	class sp_fwa_machinegun_base: sp_fwa_rifle_762_base
+	{
+		weaponInfoType="GRCB_machinegun_animation";
+	};
+};
+

--- a/src/@UNIF BASE/addons/UNIF_Belt_Fix/fncs/fnc_gpmgweaponrested.sqf
+++ b/src/@UNIF BASE/addons/UNIF_Belt_Fix/fncs/fnc_gpmgweaponrested.sqf
@@ -1,0 +1,45 @@
+private _unit = missionNamespace getVariable ["bis_fnc_moduleRemoteControl_unit", player]; //Get player unit
+
+if(!(local _unit))exitWith{};
+
+private _allowedWeapon = ["sp_fwa_mag58","sp_fwa_m60","sp_fwa_m60_early","sp_fwa_aa52","sp_fwa_aa_nf1","sp_fwa_mg4259","sp_fwa_mg3"];
+
+
+_unit addEventHandler ["WeaponDeployed", { //Deploying plays animation for holding stock
+	params ["_unitDeploying", "_isDeployed"];
+
+ 	private _currentWeapon = currentWeapon _unitDeploying;
+	private _allowedWeapon = ["sp_fwa_mag58","sp_fwa_m60","sp_fwa_m60_early","sp_fwa_aa52","sp_fwa_aa_nf1","sp_fwa_mg4259","sp_fwa_mg3"];
+ 	private _anim = "sp_fwa_GestureDeployedMachinegun";
+
+	if(not(isnull _unitDeploying)) then {
+		if (_currentWeapon in _allowedWeapon) then{
+			if(_isDeployed) then {
+				_unitDeploying playAction _anim;
+		  }else{
+				_unitDeploying playAction "gestureNod";
+		  };
+	  };
+	} else {
+		_unit removeEventHandler ["WeaponDeployed", _thisEventHandler];
+	};
+}];
+
+
+_unit addEventHandler ["Take", { //When reloading, check if weapon is deployed and if so play animation for holding stock
+	params ["_unitTaking"];
+	private _currentWeapon = currentWeapon _unitTaking;
+	private _allowedWeapon = ["sp_fwa_mag58","sp_fwa_m60","sp_fwa_m60_early","sp_fwa_aa52","sp_fwa_aa_nf1","sp_fwa_mg4259","sp_fwa_mg3"];
+ 	private _anim = "sp_fwa_GestureDeployedMachinegun";
+
+	if(not(isnull _unitTaking)) then {
+		if (_currentWeapon in _allowedWeapon) then{
+			if(isWeaponDeployed _unitTaking) then {
+				_unitTaking playAction _anim;
+		  };
+		};
+	} else {
+		_unit removeEventHandler ["Take", _thisEventHandler];
+	};
+}];
+

--- a/src/@UNIF BASE/addons/UNIF_Belt_Fix/pbo.json
+++ b/src/@UNIF BASE/addons/UNIF_Belt_Fix/pbo.json
@@ -1,0 +1,15 @@
+{
+    "compress": {
+        "exclude": [
+        ],
+        "include": [
+        ]
+    },
+    "headers": [
+        {
+            "name": "prefix",
+            "value": "UNIF_Belt_Fix"
+        }
+    ]
+}
+


### PR DESCRIPTION
Fixes the affected machine guns from Free World Armory automatically unwrapping their belts once the players goes prone while wielding them. The equivalent mod by Georg Ravioli in the UNIF mod list will be redundant once this commit has been published to the workshop.